### PR TITLE
Force config whitelist --auto to use IPv4

### DIFF
--- a/core/python/utils.py
+++ b/core/python/utils.py
@@ -4,11 +4,22 @@ import random
 import re
 import string
 import subprocess
+import socket
 import tempfile
 import yaml
 import requests
 
+import requests.packages.urllib3.util.connection as urllib3_cn
+
 from core.python.python_terraform import VariableFiles, Terraform
+
+
+def allowed_gai_family():
+    """Monkey patch for urllib3_cn.allowed_gai_family which forces IPv4 connections."""
+    return socket.AF_INET
+
+
+urllib3_cn.allowed_gai_family = allowed_gai_family
 
 
 class PatchedVariableFiles(VariableFiles):


### PR DESCRIPTION
Currently `./cloudgoat.py config whitelist --auto` breaks when IPv6 is available.
This monkeypatches the requests library to force use of IPv4. This should be ok
since the scenarios don't support IPv6 currently, we may want to change this if
support is added in the future however.